### PR TITLE
Add HTTP streaming for local models

### DIFF
--- a/xtts_api_server/tts_funcs.py
+++ b/xtts_api_server/tts_funcs.py
@@ -382,7 +382,7 @@ class TTSWrapper:
 
         if len(file_chunks) > 0:
             wav = torch.cat(file_chunks, dim=0)
-            torchaudio.save(output_file, wav.squeeze().unsqueeze(0), 24000)
+            torchaudio.save(output_file, wav.cpu().squeeze().unsqueeze(0), 24000)
         else:
             logger.warning("No audio generated.")
 

--- a/xtts_api_server/tts_funcs.py
+++ b/xtts_api_server/tts_funcs.py
@@ -374,7 +374,7 @@ class TTSWrapper:
             if isinstance(chunk, list):
                 chunk = torch.cat(chunk, dim=0)
             file_chunks.append(chunk)
-            chunk = chunk.numpy()
+            chunk = chunk.cpu().numpy()
             chunk = chunk[None, : int(chunk.shape[0])]
             chunk = np.clip(chunk, -1, 1)
             chunk = (chunk * 32767).astype(np.int16)


### PR DESCRIPTION
## Description
Adds a proper TTS streaming via HTTP by using coqui's inference_stream method and fastapi's StreamingResponse. The client can consume the new data as soon as it's ready. I found the chunk size of 100 (coqui tokens I assume?) to provide a favorable latency/interruption rate on my MacBook running CPU inference.

## Implications
1. Works only with local models.
2. Uses HTTP GET instead of HTTP POST. Explanation below.

Initially, I wanted to stick to HTTP POST requests only and do audio playback using client-side JavaScript, but unfortunately [MediaSource](https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/addSourceBuffer) does not support working with WAV data. Adding intermediate compression would only increase latency and create more complexity. Using HTTP GET allows doing playback directly from HTML by setting the audio source to the API endpoint, the browser will do all the buffering and decoding at no extra cost.

Related SillyTavern pull request: https://github.com/SillyTavern/SillyTavern/pull/1623

## References
- https://github.com/erew123/alltalk_tts/pull/36
- https://docs.coqui.ai/en/latest/models/xtts.html#streaming-manually
- https://fastapi.tiangolo.com/advanced/custom-response/#streamingresponse