### PR TITLE
Fix for path traversal vulenerability

### DIFF
--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -173,6 +173,10 @@ def get_tts_settings():
 
 @app.get("/sample/{file_name:path}")
 def get_sample(file_name: str):
+    # A fix for path traversal vulenerability. 
+    # An attacker may summon this endpoint with ../../etc/passwd and recover the password file of your PC (in linux) or access any other file on the PC
+    if ".." in file_name:
+        raise HTTPException(status_code=404, detail=".. in the file name! Are you kidding me?") 
     file_path = os.path.join(XTTS.speaker_folder, file_name)
     if os.path.isfile(file_path):
         return FileResponse(file_path, media_type="audio/wav")


### PR DESCRIPTION
Hi, I have spotted a path traversal vulenerability in the XTTS server that allows an attacker to access any file on the host.
I have added the following to the endpoint to forbid the recovery of files outside the served folder.

```python
    # A fix for path traversal vulenerability. 
    # An attacker may summon this endpoint with ../../etc/passwd and recover the password file of your PC (in linux) or access any other file on the PC
    if ".." in file_name:
        raise HTTPException(status_code=404, detail=".. in the file name! Are you kidding me?") 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
	- Enhanced security for the `get_sample` endpoint to prevent path traversal attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->