### PR TITLE
Fix for '/tts_to_audio' api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "xtts-api-server"
-version = "0.8.5"
+version = "0.8.6"
 authors = [
   { name="daswer123", email="daswerq123@gmail.com" },
 ]
@@ -33,7 +33,8 @@ dependencies = [
   "cutlet",
   'fugashi[unidic-lite]',
   'tts==0.21.3',
-  'transformers==4.36.2'
+  'transformers==4.36.2',
+  "uuid"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cutlet
 fugashi[unidic-lite]
 tts==0.21.3
 transformers==4.36.2
+uuid


### PR DESCRIPTION
There's currently a bug #59 where when the cache is disabled and you do multiple requests to `/tts_to_audio` in quick succession you'll get the same wav file in the response for all requests. Atleast this is what happened to me when using the api.

This fixes the issue by giving each file generated a unique name.
I also made it so that when the cache is disabled the generated file gets automatically deleted afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced text-to-speech functionality to support background tasks for improved performance.
	- Introduced conditional caching for audio output to optimize storage usage based on user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->