### PR TITLE
Add missing binary dependencies to Linux install documentaiton

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install torch==2.1.1+cu118 torchaudio==2.1.1+cu118 --index-url https://downl
 
 ### Linux
 ```bash
+sudo apt-get install -y python3-dev python3-venv portaudio19-dev
 python -m venv venv
 source venv\bin\activate
 pip install xtts-api-server

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install torch==2.1.1+cu118 torchaudio==2.1.1+cu118 --index-url https://downl
 
 ### Linux
 ```bash
-sudo apt-get install -y python3-dev python3-venv portaudio19-dev
+sudo apt install -y python3-dev python3-venv portaudio19-dev
 python -m venv venv
 source venv\bin\activate
 pip install xtts-api-server


### PR DESCRIPTION
Hi there 👋,

Love this work you are doing here. I noticed some binary dependencies were missing during the installation on a fresh Ubuntu image. PyAudio needs headers for portaudio and python to compile the wheel. I added instructions for apt (only works on Ubuntu) that should help most people. Users on other distros will probably be savvy enough to know how to adapt this to their package manager.

Cheers
Joe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated Linux installation instructions in the README to include additional required packages for setting up the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->