### PR TITLE
'/tts_stream' - synchronize TTS generation to prevent model crashes

### DIFF
--- a/start Normal.bat
+++ b/start Normal.bat
@@ -1,0 +1,34 @@
+call venv\Scripts\activate
+
+REM das Argument gibt an, welcher Lautsprecher das ganze ausgeben soll.
+REM Du kannst dir alle Audio Devices anschauen mit: call list_AudioDevices.bat
+REM Auskommentieren, um das Standart Gerät zu benutzen.
+REM set AUDIO_DEVICE=13
+
+
+
+
+REM usage: xtts_api_server [-h] [-hs HOST] [-p PORT] [-sf SPEAKER_FOLDER] [-o OUTPUT] [-t TUNNEL_URL] [-ms MODEL_SOURCE] [--listen] [--use-cache] [--lowvram] [--deepspeed] [--streaming-mode] [--stream-play-sync]
+REM 
+REM 
+REM options:
+REM   -h, --help show this help message and exit
+REM   -hs HOST, --host HOST
+REM   -p PORT, --port PORT
+REM   -d DEVICE, --device DEVICE `cpu` or `cuda`, you can specify which video card to use, for example, `cuda:0`
+REM   -sf SPEAKER_FOLDER, --speaker-folder The folder where you get the samples for tts
+REM   -o OUTPUT, --output Output folder
+REM   -mf MODELS_FOLDERS, --model-folder Folder where models for XTTS will be stored, finetuned models should be stored in this folder
+REM   -t TUNNEL_URL, --tunnel URL of tunnel used (e.g: ngrok, localtunnel)
+REM   -ms MODEL_SOURCE, --model-source ["api","apiManual","local"]
+REM   -v MODEL_VERSION, --version You can download the official model or your own model, official version you can find [here](https://huggingface.co/coqui/XTTS-v2/tree/main)  the model version name is the same as the branch name [v2.0.2,v2.0.3, main] etc. Or you can load your model, just put model in models folder
+REM   --listen Allows the server to be used outside the local computer, similar to -hs 0.0.0.0
+REM   --use-cache Enables caching of results, your results will be saved and if there will be a repeated request, you will get a file instead of generation
+REM   --lowvram The mode in which the model will be stored in RAM and when the processing will move to VRAM, the difference in speed is small
+REM   --deepspeed allows you to speed up processing by several times, automatically downloads the necessary libraries
+REM   --streaming-mode Enables streaming mode, currently has certain limitations, as described below.
+REM   --streaming-mode-improve Enables streaming mode, includes an improved streaming mode that consumes 2gb more VRAM and uses a better tokenizer and more context.
+REM   --stream-play-sync Additional flag for streaming mod that allows you to play all audio one at a time without interruption
+
+python -m xtts_api_server --lowvram --deepspeed -sf speakers -d cuda:0 -v thorsten.medium
+pause

--- a/start StreamingMode.bat
+++ b/start StreamingMode.bat
@@ -1,0 +1,34 @@
+call venv\Scripts\activate
+
+REM das Argument gibt an, welcher Lautsprecher das ganze ausgeben soll.
+REM Du kannst dir alle Audio Devices anschauen mit: call list_AudioDevices.bat
+REM Auskommentieren, um das Standart Gerät zu benutzen.
+REM set AUDIO_DEVICE=13
+
+
+
+
+REM usage: xtts_api_server [-h] [-hs HOST] [-p PORT] [-sf SPEAKER_FOLDER] [-o OUTPUT] [-t TUNNEL_URL] [-ms MODEL_SOURCE] [--listen] [--use-cache] [--lowvram] [--deepspeed] [--streaming-mode] [--stream-play-sync]
+REM 
+REM 
+REM options:
+REM   -h, --help show this help message and exit
+REM   -hs HOST, --host HOST
+REM   -p PORT, --port PORT
+REM   -d DEVICE, --device DEVICE `cpu` or `cuda`, you can specify which video card to use, for example, `cuda:0`
+REM   -sf SPEAKER_FOLDER, --speaker-folder The folder where you get the samples for tts
+REM   -o OUTPUT, --output Output folder
+REM   -mf MODELS_FOLDERS, --model-folder Folder where models for XTTS will be stored, finetuned models should be stored in this folder
+REM   -t TUNNEL_URL, --tunnel URL of tunnel used (e.g: ngrok, localtunnel)
+REM   -ms MODEL_SOURCE, --model-source ["api","apiManual","local"]
+REM   -v MODEL_VERSION, --version You can download the official model or your own model, official version you can find [here](https://huggingface.co/coqui/XTTS-v2/tree/main)  the model version name is the same as the branch name [v2.0.2,v2.0.3, main] etc. Or you can load your model, just put model in models folder
+REM   --listen Allows the server to be used outside the local computer, similar to -hs 0.0.0.0
+REM   --use-cache Enables caching of results, your results will be saved and if there will be a repeated request, you will get a file instead of generation
+REM   --lowvram The mode in which the model will be stored in RAM and when the processing will move to VRAM, the difference in speed is small
+REM   --deepspeed allows you to speed up processing by several times, automatically downloads the necessary libraries
+REM   --streaming-mode Enables streaming mode, currently has certain limitations, as described below.
+REM   --streaming-mode-improve Enables streaming mode, includes an improved streaming mode that consumes 2gb more VRAM and uses a better tokenizer and more context.
+REM   --stream-play-sync Additional flag for streaming mod that allows you to play all audio one at a time without interruption
+
+python -m xtts_api_server --lowvram --streaming-mode-improve --stream-play-sync --deepspeed -sf speakers -d cuda:0 -v thorsten.medium
+pause

--- a/xtts_api_server/RealtimeTTS/stream_player.py
+++ b/xtts_api_server/RealtimeTTS/stream_player.py
@@ -9,6 +9,7 @@ import logging
 import queue
 import time
 import io
+import os
 
 
 class AudioConfiguration:
@@ -22,10 +23,19 @@ class AudioConfiguration:
             format (int): Audio format, defaults to pyaudio.paInt16
             channels (int): Number of channels, defaults to 1 (mono)
             rate (int): Sample rate, defaults to 16000
+            output_device_index (int): Index of the output device to use, defaults to None (system default)
         """
         self.format = format
         self.channels = channels
         self.rate = rate
+        # Hole den Wert der Umgebungsvariablen
+        audio_device_index_str = os.getenv('AUDIO_DEVICE')
+        
+        # Versuche, den Wert in eine Ganzzahl zu konvertieren, setze auf None bei Fehler
+        try:
+            self.output_device_index = int(audio_device_index_str) if audio_device_index_str is not None else None
+        except ValueError:
+            self.output_device_index = None
 
 
 class AudioStream:
@@ -45,7 +55,6 @@ class AudioStream:
     def open_stream(self):
         """Opens an audio stream."""
 
-        # check for mpeg format
         pyChannels = self.config.channels
         pySampleRate = self.config.rate
 
@@ -56,7 +65,13 @@ class AudioStream:
             pyFormat = self.config.format
             logging.debug(f"Opening stream for wave audio chunks, pyFormat: {pyFormat}, pyChannels: {pyChannels}, pySampleRate: {pySampleRate}")
 
-        self.stream = self.pyaudio_instance.open(format=pyFormat, channels=pyChannels, rate=pySampleRate, output=True)
+        self.stream = self.pyaudio_instance.open(
+            format=pyFormat,
+            channels=pyChannels,
+            rate=pySampleRate,
+            output=True,
+            output_device_index=self.config.output_device_index  # Use the specified device index
+        )
 
     def start_stream(self):
         """Starts the audio stream."""

--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -114,7 +114,7 @@ def play_stream(stream,language):
       stream.play()
     else:
       stream.play_async()
-
+      
 class OutputFolderRequest(BaseModel):
     output_folder: str
 
@@ -170,7 +170,15 @@ def get_folders():
 @app.get("/get_models_list")
 def get_models_list():
     return XTTS.get_models_list()
-
+    
+@app.get("/get_stream_mode/")
+def check_stream_mode():
+    return {
+        "STREAM_MODE": STREAM_MODE,
+        "STREAM_MODE_IMPROVE": STREAM_MODE_IMPROVE,
+        "STREAM_PLAY_SYNC": STREAM_PLAY_SYNC
+    }
+    
 @app.get("/get_tts_settings")
 def get_tts_settings():
     settings = {**XTTS.tts_settings,"stream_chunk_size":XTTS.stream_chunk_size}

--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -14,6 +14,7 @@ from loguru import logger
 from argparse import ArgumentParser
 from pathlib import Path
 from uuid import uuid4
+import asyncio
 
 from xtts_api_server.tts_funcs import TTSWrapper,supported_languages,InvalidSettingsError
 from xtts_api_server.RealtimeTTS import TextToAudioStream, CoquiEngine
@@ -36,6 +37,9 @@ USE_CACHE = os.getenv("USE_CACHE") == 'true'
 STREAM_MODE = os.getenv("STREAM_MODE") == 'true'
 STREAM_MODE_IMPROVE = os.getenv("STREAM_MODE_IMPROVE") == 'true'
 STREAM_PLAY_SYNC = os.getenv("STREAM_PLAY_SYNC") == 'true'
+
+# global lock for synchronized TTS generation
+tts_lock = asyncio.Lock()
 
 if(DEEPSPEED):
   install_deepspeed_based_on_python_version()
@@ -223,30 +227,27 @@ def set_tts_settings_endpoint(tts_settings_req: TTSSettingsRequest):
 
 @app.get('/tts_stream')
 async def tts_stream(request: Request, text: str = Query(), speaker_wav: str = Query(), language: str = Query()):
-    # Validate local model source.
     if XTTS.model_source != "local":
-        raise HTTPException(status_code=400,
-                            detail="HTTP Streaming is only supported for local models.")
-    # Validate language code against supported languages.
+        raise HTTPException(status_code=400, detail="HTTP Streaming is only supported for local models.")
+    
     if language.lower() not in supported_languages:
-        raise HTTPException(status_code=400,
-                            detail="Language code sent is either unsupported or misspelled.")
-            
+        raise HTTPException(status_code=400, detail="Language code sent is either unsupported or misspelled.")
+
     async def generator():
-        chunks = XTTS.process_tts_to_file(
-            text=text,
-            speaker_name_or_path=speaker_wav,
-            language=language.lower(),
-            stream=True,
-        )
-        # Write file header to the output stream.
-        yield XTTS.get_wav_header()
-        async for chunk in chunks:
-            # Check if the client is still connected.
-            disconnected = await request.is_disconnected()
-            if disconnected:
-                break
-            yield chunk
+        # wait until the lock is available
+        async with tts_lock:
+            chunks = XTTS.process_tts_to_file(
+                text=text,
+                speaker_name_or_path=speaker_wav,
+                language=language.lower(),
+                stream=True,
+            )
+            yield XTTS.get_wav_header()
+            async for chunk in chunks:
+                disconnected = await request.is_disconnected()
+                if disconnected:
+                    break
+                yield chunk
 
     return StreamingResponse(generator(), media_type='audio/x-wav')
 


### PR DESCRIPTION
### Synchronize `/tts_stream` generation to prevent concurrent model crashes

This PR introduces a global `asyncio.Lock` in the `/tts_stream` endpoint to ensure that only one request at a time can perform TTS audio **generation**.

Previously, sending multiple `/tts_stream` requests in parallel could cause the underlying model to crash due to concurrent generation attempts. With this change, requests now wait for the current generation to finish before starting a new one.

**Key points:**

* Added a shared `asyncio.Lock` around the generation logic.
* Only the generation process is synchronized — audio **playback** of already-generated streams remains concurrent.
* No changes to API parameters or response format.

**Why:**
Prevent model crashes and ensure stability when multiple clients attempt to generate speech at the same time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents concurrent TTS streams so only one active stream emits a single WAV header; improves client-disconnection handling.
  * Added checks to validate requested speaker files and to block path-traversal attempts when serving samples.

* **New Features**
  * New endpoint to report current streaming configuration.
  * Honor AUDIO_DEVICE environment variable to select audio output device.

* **Documentation / Utilities**
  * Added Windows starter scripts with usage guidance and sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->